### PR TITLE
Only install mssql-server-agent if 2017

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,7 +84,7 @@
   environment:
     ACCEPT_EULA: Y
   when:
-    - ansible_distribution != "Ubuntu"
+    - ansible_distribution != "Ubuntu" and mssql_version == 2017
   notify:
     - restart mssql-server
 
@@ -96,7 +96,7 @@
   environment:
     ACCEPT_EULA: Y
   when:
-    - ansible_distribution == "Ubuntu"
+    - ansible_distribution == "Ubuntu" and mssql_version == 2017
   notify:
     - restart mssql-server
 


### PR DESCRIPTION
---
name: Pull request
about: Only install mssql-server-agent if 2017 - it's been merged into mssql-tools in 2019.

---

**Describe the change**
Only trying to install mssql-server-agent if on version 2017.
